### PR TITLE
allow to create only some columns from iterator

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,9 +10,16 @@ it = TableTraitsUtils.create_tableiterator(columns, names)
 
 columns2, names2 = TableTraitsUtils.create_columns_from_iterabletable(it)
 
+columns23, names23 = TableTraitsUtils.create_columns_from_iterabletable(it, [2,3])
+
 @test columns[1] == columns2[1]
 @test columns[2] == columns2[2]
 @test columns[3] == columns2[3]
+@test columns[2] == columns23[1]
+@test columns[3] == columns23[2]
+@test length(columns23) == 2
+
 @test names == names2
+@test names[2:3] == names23
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,16 +10,19 @@ it = TableTraitsUtils.create_tableiterator(columns, names)
 
 columns2, names2 = TableTraitsUtils.create_columns_from_iterabletable(it)
 
+columns3, names3 = TableTraitsUtils.create_columns_from_iterabletable(it, :all)
+
 columns23, names23 = TableTraitsUtils.create_columns_from_iterabletable(it, [2,3])
 
-@test columns[1] == columns2[1]
-@test columns[2] == columns2[2]
-@test columns[3] == columns2[3]
+@test columns[1] == columns2[1] == columns3[1]
+@test columns[2] == columns2[2] == columns3[2]
+@test columns[3] == columns2[3] == columns3[3]
+@test length(columns) == length(columns2) == length(columns3)
 @test columns[2] == columns23[1]
 @test columns[3] == columns23[2]
 @test length(columns23) == 2
 
-@test names == names2
+@test names == names2 == names3
 @test names[2:3] == names23
 
 end


### PR DESCRIPTION
As discussed in the StatPlots issue [#82](https://github.com/JuliaPlots/StatPlots.jl/pull/82), a possible implementation for creating only some columns of the iterator. I tried to code it in such a way that, in case of default value, there really is no change at all in the function behavior.